### PR TITLE
Fix and improvements1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ Oh Brother! is a simple cross-platform utility written in Python which can
 update Brother printer firmwares.  It was born out of frustration with Brother
 for not providing a tool which works in Linux.  This tool should work on any
 platform that has Python with ```python-pysnmp4```.  It was tested with Python
-v2.7.8.
+v2.7.8 and v2.7.5.
 
 I found information on how to do this
 [here](https://cbompart.wordpress.com/2014/02/05/printer-update/) and
 [here](http://pschla.blogspot.com/2013/08/resurrecting-brother-hl-2250dn-after.html).
 
-# Install prerequisites on Debian or Ubuntu
+# Install prerequisites on Debian-based distributions (e.g. Debian/Mint/Ubuntu)
 
 ```
 sudo apt-get install python-pysnmp4

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Currently the script does the following:
   * For each firmware type:
     * Query Brother servers for the latest firmware.
     * Download the firmware from Brother.
+    * Display firmware info, then ask user whether to proceed with updating.
     * Upload the firmware via FTP to the printer.
     * Wait for user to signal that the update is done.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ sudo apt-get install python-pysnmp4
 ```
 
 # What it does
-Curently the script does the following:
+Currently the script does the following:
 
   * Query the printer's information via the SNMP protocol.
   * Print SNMP info to screen.

--- a/oh-brother.py
+++ b/oh-brother.py
@@ -67,8 +67,8 @@ for arg in sys.argv[1:]:
   else: ip = arg
 
 
-# Get SMNP data
-print 'Getting SNMP data from printer at %s...' % ip,
+# Get SNMP data
+print 'Getting SNMP data from printer at %s...' % ip
 sys.stdout.flush()
 
 cg = cmdgen.CommandGenerator()
@@ -171,7 +171,7 @@ def update_firmware(cat, version):
       'fileUpdate'
   hdrs = {'Content-Type': 'text/xml'}
 
-  print 'Looking up printer firmware...',
+  print 'Looking up printer firmware...'
   sys.stdout.flush()
 
   import urllib2
@@ -206,7 +206,7 @@ def update_firmware(cat, version):
   # Download firmware
   f = open(filename, 'w')
 
-  print 'Downloading firmware %s...' % filename,
+  print 'Downloading firmware %s...' % filename
   sys.stdout.flush()
 
   req = urllib2.Request(firmwareURL)
@@ -233,7 +233,7 @@ def update_firmware(cat, version):
   # Upload firmware to printer
   from ftplib import FTP
 
-  print 'Uploading firmware to printer...',
+  print 'Uploading firmware to printer...'
   sys.stdout.flush()
 
   ftp = FTP(ip, user = password) # Yes send password as user

--- a/oh-brother.py
+++ b/oh-brother.py
@@ -144,7 +144,15 @@ def update_firmware(cat, version):
   # Build XML request info
   xml = ET.ElementTree(ET.fromstring(reqInfo))
 
-  xml.find('FIRMUPDATETOOLINFO/FIRMCATEGORY').text = cat
+  # At least for MFC-J4510DW M1405200717:EFAC (see Internet dumps)
+  # and MFC-J4625DW,
+  # this element's value is *not* equal to per-firmware cat[egory] value
+  # (a "MAIN"-deviating "FIRM" in these cases!),
+  # but rather a *fixed* "MAIN" value which is a completely unrelated item,
+  # thus I assume this to model-unconditionally have been a BUG
+  # (which causes a failure response of the web service request).
+  #xml.find('FIRMUPDATETOOLINFO/FIRMCATEGORY').text = cat
+  xml.find('FIRMUPDATETOOLINFO/FIRMCATEGORY').text = 'MAIN'
 
   modelInfo = xml.find('FIRMUPDATEINFO/MODELINFO')
   modelInfo.find('SELIALNO').text = serial

--- a/oh-brother.py
+++ b/oh-brother.py
@@ -42,6 +42,7 @@ reqInfo = '''
 
 password = None
 verbose = False
+show_firmware_upgrade_safety_prompt = True
 
 from pysnmp.entity.rfc3413.oneliner import cmdgen
 import xml.etree.ElementTree as ET
@@ -222,6 +223,14 @@ def update_firmware(cat, version):
   print 'done'
   f.close()
 
+  if show_firmware_upgrade_safety_prompt:
+    print 'About to upload the firmware to printer.'
+    print 'This is a dangerous action since it is potentially destructive.'
+    print 'Thus please double-check / review to ensure that:'
+    print '- firmware file version is compatible with your hardware'
+    print '- network connection is maximally reliable (strongly prefer wired connection to WLAN)'
+    print '- power supply is maximally reliable (may be achieved by using a UPS)'
+    raw_input("Press Ctrl-C to prevent firmware upgrade, or possibly Enter to continue...")
 
   # Get printer password
   if password is None:
@@ -233,7 +242,7 @@ def update_firmware(cat, version):
   # Upload firmware to printer
   from ftplib import FTP
 
-  print 'Uploading firmware to printer...'
+  print 'Now uploading firmware to printer (DO NOT REMOVE POWER!)...'
   sys.stdout.flush()
 
   ftp = FTP(ip, user = password) # Yes send password as user

--- a/oh-brother.py
+++ b/oh-brother.py
@@ -15,6 +15,17 @@
 # GNU General Public License for more details.
 
 
+# TODO:
+# - should definitely attempt to have this functionality
+#   hooked up to / integrated with
+#   the new generic fwupd.org Linux service
+
+
+# Yes indeed, "SELIALNO"
+# (as used both in this here document and in script parts below)
+# is a spelling issue crime committed by original vendor parts
+# and thus expected to remain exactly as wrongly written.
+# Thus it obviously should *not* be "corrected" here.
 reqInfo = '''
 <REQUESTINFO>
     <FIRMUPDATETOOLINFO>

--- a/oh-brother.py
+++ b/oh-brother.py
@@ -172,7 +172,7 @@ def update_firmware(cat, version):
       'fileUpdate'
   hdrs = {'Content-Type': 'text/xml'}
 
-  print 'Looking up printer firmware...'
+  print 'Looking up printer firmware info at vendor server...'
   sys.stdout.flush()
 
   import urllib2
@@ -207,7 +207,7 @@ def update_firmware(cat, version):
   # Download firmware
   f = open(filename, 'w')
 
-  print 'Downloading firmware %s...' % filename
+  print 'Downloading firmware file %s from vendor server...' % filename
   sys.stdout.flush()
 
   req = urllib2.Request(firmwareURL)

--- a/oh-brother.py
+++ b/oh-brother.py
@@ -53,6 +53,8 @@ reqInfo = '''
 
 password = None
 verbose = False
+debug_dump_web_service_request_content = False
+debug_dump_web_service_response_content = False
 show_firmware_upgrade_safety_prompt = True
 
 from pysnmp.entity.rfc3413.oneliner import cmdgen
@@ -177,6 +179,9 @@ def update_firmware(cat, version):
 
   requestInfo = ET.tostring(xml.getroot(), encoding = 'utf8')
 
+  if debug_dump_web_service_request_content:
+    print 'request: %s' % requestInfo
+
 
   # Request firmware data
   url = 'https://firmverup.brother.co.jp/kne_bh7_update_nt_ssl/ifax2.asmx/' + \
@@ -193,6 +198,8 @@ def update_firmware(cat, version):
 
   print 'done'
 
+  if debug_dump_web_service_response_content:
+    print 'response: %s' % response
 
   # Parse response
   xml = ET.fromstring(response)


### PR DESCRIPTION
Hi,

this obsoletes prior pull request of my unspecifically named work branch.

Differences:
- corrected brand name to "Mint" (was: "MINT")
- stress that firmware category "MAIN" value is "completely unrelated" to the "other" "MAIN"

----------

Hi,

noticed that it fell flat on its face on my MFC-J4625DW.

"Please feel free to submit a pull-request."

Hell yes :)

These additions ought to prove rather useful...

Note that I didn't do full end-to-end testing (i.e., plus FTP firmware update), but that should not really matter (actual operation is a lot better now).

Thanks a ton for a very useful tool! (and no thanks to Brother in this particular case of providing rather unusable support level, as opposed to other areas where it's much better)

Andreas Mohr