### PR TITLE
Add python3-future as Debian-based dependency for py3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Python 2:
     sudo apt-get install -y python-pysnmp4
 
 Python 3:
-    sudo apt-get install -y python3-pysnmp4
+    sudo apt-get install -y python3-future python3-pysnmp4
 
 ## On RedHat-based distributions (e.g. Fedora/CentOS)
 


### PR DESCRIPTION
Hi there,

Thanks for putting this tool together! I ran into this utility while trying to figure out how to update my printer's firmware from my chromebook. The very minimal debian-based vm it provides needed an additional package that I assume is already installed in many other distros.

I'm assuming (perhaps incorrectly) that this package is available in other debian-based distros and that just adding it in for any apt install won't cause a problem. If that turns out to be wrong, I'd be happy to redo it as its own section.