### PR TITLE
Fix #29

### DIFF
--- a/oh-brother.py
+++ b/oh-brother.py
@@ -42,7 +42,7 @@ reqInfo = '''
             <SELIALNO></SELIALNO>
             <NAME></NAME>
             <SPEC></SPEC>
-            <DRIVER></DRIVER>
+            <DRIVER>EWS</DRIVER>
             <FIRMINFO>
               <FIRM></FIRM>
             </FIRMINFO>


### PR DESCRIPTION
The server apparently returns an empty response for some printers if this `<DRIVER>` field is empty (it doesn't actually seem to matter what the `<DRIVER>` field contains, as long as it's not empty -- but I kept the original string from the intercepted official requests, just in case).

There is a (small?) chance that this will break the script for the other printers (those that previously worked with an empty `<DRIVER>` field). This seemed unlikely to me, but it would probably be useful if someone could test it before this pull request is merged (I only have 1 Brother printer and that one requires non-empty `<DRIVER>`). If this breaks the script for some other printers, we can probably implement a more complicated solution (e.g. the script could try both versions of the request).