### PR TITLE
Update README.md (ModuleNotFoundErrors workaround)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ sudo apt-get install -y python3-pysnmp4
 sudo yum install python-pysnmp
 ```
 
-## On OSX or Windows with Python installer (PIP)
+## On MacOS or Windows with Python installer (PIP)
 
 ```
-pip install pysnmp
+pip install pysnmp==4.4.12
+pip install pyasn1==0.4.8
 ```
 
 # What it does


### PR DESCRIPTION
Workaround for ModuleNotFoundErrors caused by external changes.

No module named 'pysnmp.entity.rfc3413.oneliner'
https://github.com/lextudio/pysnmp/issues/112

No module named 'pyasn1.compat.octets'
https://github.com/pyasn1/pyasn1/issues/76