### PR TITLE
Add requirements.txt and fix PySNMP dependency versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ I hope people find this project useful but I am not getting paid for it.  If you
 
 # Install prerequisites
 
+The `requirements.txt` file contains the required dependency versioning for
+the PySNMP dependency. It can be installed with:
+
+```
+pip install -r requirements.txt
+```
+
 ## On Debian-based distributions (e.g. Debian/Mint/Ubuntu)
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+# oh-brother uses the `pysnmp.entity.rfc3413.oneliner` module, which was
+# removed in v6.2 (see https://github.com/lextudio/pysnmp/compare/v6.1.4..v6.2).
+# So v6.1.4 is the highest version of PySNMP that we can currently use.
+#
+# Additionally, Python 3.12 completely removes the `asyncore` module from
+# the standard library, so PySNMP versions older than 6.x do not work with
+# it.
+
+pysnmp >= 4, <= 6.1.4 ; python_version < "3.12"
+pysnmp >= 6, <= 6.1.4 ; python_version >= "3.12"


### PR DESCRIPTION
PySNMP 4.x is now thoroughly obsolete.  It cannot be used *at all* with Python 3.12, which removed from the standard library the `asyncore` module on which it depended.

Additionally, pysnmp 6.2 [removed the "oneliner" interface](https://github.com/lextudio/pysnmp/compare/v6.1.4..v6.2) which this script currently [uses](https://github.com/CauldronDevelopmentLLC/oh-brother/blob/078f8baa8eabbe719ad75574a7b846478d1d07b4/oh-brother.py#L17).

Therefore, in order to continue using this script:

- with Python 3.12: PySNMP >= 6 and < 6.2 is required
- with older Python 3.x: PySNMP >= 4 and < 6.2 is required