### PR TITLE
Add --download-only mode to fetch firmware without a printer

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,31 @@ Try specifying ``--category`` on the command line.  E.g.:
 This will force the script to update a specific firmware regardless of the
 version you currently have.
 
+## Download firmware without the printer
+
+The vendor's update server resolves the firmware image from model and SPEC
+alone, so the tool can download the image without a printer being present
+on the network:
+
+    ./oh-brother.py --download-only -m "Brother HL-L2375DW series" -S <SPEC> -c MAIN -f 1.77
+
+``--model`` and ``--spec`` are required in this mode.  SPEC is a per
+model/region code; if you do have the printer reachable, read it via
+SNMP instead:
+
+    snmpget -v1 -c public <printer-ip> 1.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2
+
+Note that the version passed with ``-f`` should be a real lower version
+currently installed (e.g. ``1.77``); placeholder values such as ``0`` or
+``1.0`` are rejected by the vendor server with a ``VERSIONCHECK=2``
+response.
+
+If the server rejects the model/SPEC combination, the tool now prints a
+clear error instead of exiting silently.  On models with an NC-9300h
+network card, the SNMP agent lives on the network card and expects the
+community ``public``; unknown communities are silently dropped, which
+looks like a timeout.
+
 ## Submit a PR
 Please feel free to submit a pull-request.
 

--- a/oh-brother.py
+++ b/oh-brother.py
@@ -56,18 +56,26 @@ reqInfo = '''
 '''
 
 # Parse args
-usage = '%(prog)s [OPTIONS] <printer IP address>'
+usage = '%(prog)s [OPTIONS] [printer IP address]'
 description = 'A platform independent tool for updating Brother firmwares'
 
 parser = argparse.ArgumentParser(usage = usage, description = description)
 
-parser.add_argument('ip', metavar = 'IP', help = 'printer IP address')
+parser.add_argument('ip', metavar = 'IP', nargs = '?',
+                    help = 'printer IP address '
+                           '(optional when using --download-only)')
 parser.add_argument('-v', '--verbose', action = 'store_true',
                     help = 'Verbose output')
 parser.add_argument('-c', '--category',
                     help = 'Force a specific firmware category')
 parser.add_argument('-m', '--model',
                     help = 'Force a specific printer model')
+parser.add_argument('-S', '--spec',
+                    help = 'Force a specific SPEC value (required when no '
+                           'printer IP address is given)')
+parser.add_argument('--download-only', action = 'store_true',
+                    help = 'Only download the firmware file, do not upload '
+                           'it to the printer')
 parser.add_argument('-C', '--community', default = 'public',
                     help = 'SNMP community (default: %(default)s)')
 parser.add_argument('-f', '--version', default = 'B0000000000',
@@ -85,56 +93,73 @@ parser.add_argument('-p', '--password',
 args = parser.parse_args()
 
 # Provide information about requirements
-print('You may need to check the following in the printer\'s configuration:')
-print('  - SNMP service is enabled (for fetching model and versions)')
-if args.password:
-  print('  - FTP service is enabled (for uploading firmware)')
-  print('  - an administrator password is set (for connecting to FTP)')
-input('Press Ctrl-C to exit or Enter to continue...')
+if args.ip:
+  print('You may need to check the following in the printer\'s configuration:')
+  print('  - SNMP service is enabled (for fetching model and versions)')
+  if args.password:
+    print('  - FTP service is enabled (for uploading firmware)')
+    print('  - an administrator password is set (for connecting to FTP)')
+  input('Press Ctrl-C to exit or Enter to continue...')
+
+# When there is no printer to query, the model and SPEC have to be given
+# explicitly.
+if args.ip is None:
+  if not (args.model and args.spec):
+    parser.error('--model and --spec are required when no printer IP '
+                 'address is given')
 
 # Get SNMP data
-print('Getting SNMP data from printer at %s...' % args.ip)
-sys.stdout.flush()
-
-cg = cmdgen.CommandGenerator()
-error, status, index, table = cg.nextCmd(
-  cmdgen.CommunityData(args.community),
-  cmdgen.UdpTransportTarget((args.ip, 161)),
-  '1.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2')
-
-print('done')
-
-if error: raise Exception(error)
-if status:
-  raise Exception('ERROR: %s at %s' % (
-    status.prettyPrint(), index and table[-1][int(index) - 1] or '?'))
-
-# Process SNMP data
 serial   = None
 model    = None
 spec     = None
-firmId   = None
 firmInfo = []
 
-if args.verbose: print(table)
+if args.ip:
+  print('Getting SNMP data from printer at %s...' % args.ip)
+  sys.stdout.flush()
 
-for row in table:
-  for name, value in row:
-    value = str(value)
+  cg = cmdgen.CommandGenerator()
+  error, status, index, table = cg.nextCmd(
+    cmdgen.CommunityData(args.community),
+    cmdgen.UdpTransportTarget((args.ip, 161)),
+    '1.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2')
 
-    if value.find('=') != -1:
-      name, value = value.split('=')
-      value = value.strip(' "\r\n')
+  print('done')
 
-      if name == 'MODEL':  model  = value
-      if name == 'SERIAL': serial = value
-      if name == 'SPEC':   spec   = value
-      if name == 'FIRMID': firmId = value
-      if name == 'FIRMVER' and firmId and value:
-        firmInfo.append({'cat': firmId, 'version': value})
+  if error: raise Exception(error)
+  if status:
+    raise Exception('ERROR: %s at %s' % (
+      status.prettyPrint(), index and table[-1][int(index) - 1] or '?'))
+
+  # Process SNMP data
+  serial   = None
+  model    = None
+  spec     = None
+  firmId   = None
+  firmInfo = []
+
+  if args.verbose: print(table)
+
+  for row in table:
+    for name, value in row:
+      value = str(value)
+
+      if value.find('=') != -1:
+        name, value = value.split('=')
+        value = value.strip(' "\r\n')
+
+        if name == 'MODEL':  model  = value
+        if name == 'SERIAL': serial = value
+        if name == 'SPEC':   spec   = value
+        if name == 'FIRMID': firmId = value
+        if name == 'FIRMVER' and firmId and value:
+          firmInfo.append({'cat': firmId, 'version': value})
 
 # Override model
 if args.model: model = args.model
+
+# Override SPEC
+if args.spec: spec = args.spec
 
 # Override category and version
 if args.category:
@@ -222,10 +247,28 @@ def update_firmware(cat, version):
   xml = ET.fromstring(response)
 
   # Check version
+  # VERSIONCHECK semantics (verified against the vendor server):
+  #   0 = update available (PATH holds the download URL)
+  #   1 = already up to date
+  #   2 = invalid model name, wrong SPEC, or missing device context
+  #   empty <RESPONSEINFO/> = request not recognized
   versionCheck = xml.find('FIRMUPDATEINFO/VERSIONCHECK')
-  if versionCheck is not None and versionCheck.text == '1':
-    print('Firmware already up to date')
-    return
+  if versionCheck is not None:
+    if versionCheck.text == '1':
+      print('Firmware already up to date')
+      return
+    if versionCheck.text == '2':
+      print('ERROR: the vendor server rejected the model/SPEC combination.')
+      print('Check that --model matches the exact model name and --spec is')
+      print('correct for this printer. Without a printer, the SPEC can be')
+      print('read from the device with:')
+      print('  snmpget -v1 -c public <printer-ip> '\
+            '1.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2')
+      return
+
+  latestVersion = xml.find('FIRMUPDATEINFO/LATESTVERSION')
+  if latestVersion is not None and latestVersion.text:
+    print('Latest firmware version: %s' % latestVersion.text)
 
   # Get firmware URL
   firmwareURL = xml.find('FIRMUPDATEINFO/PATH')
@@ -255,7 +298,9 @@ def update_firmware(cat, version):
   print('done')
   f.close()
 
-  if args.test: return
+  if args.test or args.download_only:
+    print('Firmware downloaded to %s' % filename)
+    return
 
   print('About to upload the firmware to printer.')
   print('This is a dangerous action since it is potentially destructive.')


### PR DESCRIPTION
## Summary

The vendor's `fileUpdate` endpoint resolves the firmware image from the model
name and SPEC alone, so the update image can be downloaded **without a printer
being reachable on the network**. Today the script requires a printer IP,
always performs the SNMP walk, and aborts on any SNMP failure — even though
only the download half needs the printer at all.

## Changes

* Make the `IP` argument optional (`nargs='?'`).
* Add `--spec` / `-S` to provide the model's SPEC code directly (previously
  SPEC could only be read from the printer, and had no override even though
  `--model` and `--category` already had them).
* Add `--download-only` to skip the upload phase; `--test` is unchanged.
* When no IP is given, require `--model` **and** `--spec` (clear
  `parser.error` otherwise).
* Surface `VERSIONCHECK=2` (invalid model name / wrong SPEC) as an explicit
  error with a hint, instead of exiting silently with
  "No firmware update info path found".
* Print `LATESTVERSION` from the server response (was in the payload,
  previously ignored).

## Usage

```
./oh-brother.py --download-only -m "Brother HL-L2375DW series" -S <SPEC> -c MAIN -f 1.77
```

`--model`/`--spec` values can be read from a reachable printer via SNMP:

```
snmpget -v1 -c public <printer-ip> 1.3.6.1.4.1.2435.2.4.3.99.3.1.6.1.2
```

## Notes / findings from testing against the vendor server

* `VERSIONCHECK` semantics as observed: `0` = update available (PATH holds a
  plain-HTTP Akamai CDN URL, no auth), `1` = already up to date, `2` =
  invalid model name / wrong SPEC / missing device context.
* The `<VERSION>` value in the request should be a real, lower installed
  version (e.g. `1.77`); placeholder values like `0` or `1.0` get
  `VERSIONCHECK=2`.
* On models with an NC-9300h network card the SNMP agent lives on the
  network card and expects community `public`; unknown communities are
  silently dropped, which looks like a timeout. (The `--community` option
  already exists upstream — this PR only documents the failure mode.)
* README: new "Download firmware without the printer" section.

## Compatibility

Backwards compatible: existing invocations with an IP behave exactly as
before. No dependency changes. Related open PRs (#44, #47) only touch the
README and do not conflict.
